### PR TITLE
bumped wallet version to 1.2.6r1-0xenial1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ARG smartcashVersion=1.1.1rc3-0xenial1
+ARG smartcashVersion=1.2.6r1-0xenial1
 ARG _smartcashBin=/opt/smartcash/smartcashd
 ARG _entryPointBin=/opt/docker-entrypoint.sh
 


### PR DESCRIPTION
››
SmartNodes Update v1.2.4 Please note v1.1 nodes are no longer eligible for block rewards.
‹‹
https://smartnodes.cc/